### PR TITLE
Add schemas for subgraphs

### DIFF
--- a/__wundergraph__/subgraphs/employees/schema.graphql
+++ b/__wundergraph__/subgraphs/employees/schema.graphql
@@ -1,0 +1,163 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@authenticated", "@composeDirective", "@external", "@extends", "@inaccessible", "@interfaceObject", "@override", "@provides", "@key", "@requires", "@requiresScopes", "@shareable", "@tag"])
+
+directive @goField(forceResolver: Boolean, name: String, omittable: Boolean) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+type Query {
+  employee(id: Int!): Employee
+  employeeAsList(id: Int!): [Employee]
+  employees: [Employee]
+  products: [Products!]!
+  teammates(team: Department!): [Employee!]!
+  firstEmployee: Employee! @tag(name: "internal")
+}
+
+scalar Upload
+
+type Mutation {
+  updateEmployeeTag(id: Int!, tag: String!): Employee
+  singleUpload(file: Upload!): Boolean!
+  singleUploadWithInput(arg: FileUpload!): Boolean!
+  multipleUpload(files: [Upload!]!): Boolean!
+}
+
+input FileUpload {
+  nested: DeeplyNestedFileUpload
+  nestedList: [Upload!]
+}
+
+input DeeplyNestedFileUpload {
+  file: Upload!
+}
+
+type Subscription {
+  """`currentTime` will return a stream of `Time` objects."""
+  currentTime: Time!
+  countEmp(max: Int!, intervalMilliseconds: Int!): Int!
+  countEmp2(max: Int!, intervalMilliseconds: Int!): Int!
+  countFor(count: Int!): Int!
+}
+
+enum Department {
+  ENGINEERING
+  MARKETING
+  OPERATIONS
+}
+
+interface RoleType {
+  departments: [Department!]!
+  title: [String!]!
+  employees: [Employee!]! @goField(forceResolver: true)
+}
+
+enum EngineerType {
+  BACKEND
+  FRONTEND
+  FULLSTACK
+}
+
+interface Identifiable {
+  id: Int!
+}
+
+type Engineer implements RoleType {
+  departments: [Department!]!
+  title: [String!]!
+  employees: [Employee!]! @goField(forceResolver: true)
+  engineerType: EngineerType!
+}
+
+type Marketer implements RoleType {
+  departments: [Department!]!
+  title: [String!]!
+  employees: [Employee!]! @goField(forceResolver: true)
+}
+
+enum OperationType {
+  FINANCE
+  HUMAN_RESOURCES
+}
+
+type Operator implements RoleType {
+  departments: [Department!]!
+  title: [String!]!
+  employees: [Employee!]! @goField(forceResolver: true)
+  operatorType: [OperationType!]!
+}
+
+type Details {
+  forename: String! @shareable
+  location: Country!
+  surname: String! @shareable
+  pastLocations: [City!]!
+}
+
+type City {
+  type: String!
+  name: String!
+  country: Country
+}
+
+type Country @key(fields: "key { name }", resolvable: false) {
+  key: CountryKey!
+}
+
+type CountryKey {
+  name: String!
+}
+
+enum Mood {
+  HAPPY
+  SAD
+}
+
+type Employee implements Identifiable @key(fields: "id") {
+  details: Details! @shareable
+  id: Int!
+  tag: String!
+  role: RoleType!
+  notes: String @shareable
+  updatedAt: String!
+  startDate: String! @requiresScopes(scopes: [["read:employee", "read:private"], ["read:all"]])
+  currentMood: Mood! @external
+  derivedMood: Mood! @requires(fields: "currentMood")
+  isAvailable: Boolean! @external
+  rootFieldThrowsError: String @goField(forceResolver: true)
+  rootFieldErrorWrapper: ErrorWrapper @goField(forceResolver: true)
+  age: Int
+}
+
+type ErrorWrapper {
+  okField: String
+  errorField: String @goField(forceResolver: true)
+}
+
+type Time {
+  unixTime: Int!
+  timeStamp: String!
+}
+
+union Products = Consultancy | Cosmo | SDK
+
+interface IProduct {
+  upc: ID!
+  engineers: [Employee!]!
+}
+
+type Consultancy @key(fields: "upc") {
+  upc: ID!
+  lead: Employee!
+  isLeadAvailable: Boolean @requires(fields: "lead { isAvailable }")
+}
+
+type Cosmo implements IProduct @key(fields: "upc") {
+  upc: ID!
+  engineers: [Employee!]!
+  lead: Employee!
+}
+
+type SDK implements IProduct @key(fields: "upc") {
+  upc: ID!
+  engineers: [Employee!]!
+  owner: Employee!
+  unicode: String!
+}

--- a/__wundergraph__/subgraphs/employees/schema.graphql
+++ b/__wundergraph__/subgraphs/employees/schema.graphql
@@ -124,6 +124,7 @@ type Employee implements Identifiable @key(fields: "id") {
   rootFieldThrowsError: String @goField(forceResolver: true)
   rootFieldErrorWrapper: ErrorWrapper @goField(forceResolver: true)
   age: Int
+  c: String
 }
 
 type ErrorWrapper {

--- a/__wundergraph__/subgraphs/employees/schema.graphql
+++ b/__wundergraph__/subgraphs/employees/schema.graphql
@@ -125,6 +125,8 @@ type Employee implements Identifiable @key(fields: "id") {
   rootFieldErrorWrapper: ErrorWrapper @goField(forceResolver: true)
   age: Int
   c: String
+  d: String
+  e: String
 }
 
 type ErrorWrapper {

--- a/__wundergraph__/subgraphs/products/schema.graphql
+++ b/__wundergraph__/subgraphs/products/schema.graphql
@@ -1,0 +1,93 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@authenticated", "@composeDirective", "@external", "@extends", "@inaccessible", "@interfaceObject", "@override", "@provides", "@key", "@requires", "@requiresScopes", "@shareable", "@tag"])
+
+schema {
+  query: Queries
+  mutation: Mutation
+}
+
+type Queries {
+  productTypes: [Products!]!
+  topSecretFederationFacts: [TopSecretFact!]! @requiresScopes(scopes: [["read:fact"], ["read:all"]])
+  factTypes: [TopSecretFactType!]
+  sharedThings(numOfA: Int!, numOfB: Int!): [Thing!]! @shareable
+}
+
+type Mutation {
+  addFact(fact: TopSecretFactInput!): TopSecretFact! @requiresScopes(scopes: [["write:fact"], ["write:all"]])
+}
+
+type Thing @shareable {
+  a: String!
+}
+
+input TopSecretFactInput {
+  title: String!
+  description: FactContent!
+  factType: TopSecretFactType!
+}
+
+enum TopSecretFactType @authenticated {
+  DIRECTIVE
+  ENTITY
+  MISCELLANEOUS
+}
+
+interface TopSecretFact @authenticated {
+  description: FactContent!
+  factType: TopSecretFactType
+}
+
+scalar FactContent @requiresScopes(scopes: [["read:scalar"], ["read:all"]])
+
+type DirectiveFact implements TopSecretFact @authenticated {
+  title: String!
+  description: FactContent!
+  factType: TopSecretFactType
+}
+
+type EntityFact implements TopSecretFact @requiresScopes(scopes: [["read:entity"]]) {
+  title: String!
+  description: FactContent!
+  factType: TopSecretFactType
+}
+
+type MiscellaneousFact implements TopSecretFact {
+  title: String!
+  description: FactContent! @requiresScopes(scopes: [["read:miscellaneous"]])
+  factType: TopSecretFactType
+}
+
+enum ProductName {
+  CONSULTANCY
+  COSMO
+  ENGINE
+  FINANCE
+  HUMAN_RESOURCES
+  MARKETING
+  SDK
+}
+
+type Employee @key(fields: "id") {
+  id: Int!
+  products: [ProductName!]!
+  notes: String @override(from: "employees")
+  a: String
+}
+
+union Products = Consultancy | Cosmo | Documentation
+
+type Consultancy @key(fields: "upc") {
+  upc: ID!
+  name: ProductName!
+}
+
+type Cosmo @key(fields: "upc") {
+  upc: ID!
+  name: ProductName!
+  repositoryURL: String!
+}
+
+type Documentation {
+  url(product: ProductName!): String!
+  urls(products: [ProductName!]!): [String!]!
+}


### PR DESCRIPTION
This PR adds/updates the GraphQL schemas for the following subgraphs:

- employees
- products

Created by WunderGraph Hub.